### PR TITLE
Correcting the links in the Evidence column on the Annotations results

### DIFF
--- a/app/annotationsList/annotationList.html
+++ b/app/annotationsList/annotationList.html
@@ -54,9 +54,12 @@
 
           <!-- Evidence: ECO:0000256  (IEA) -->
           <td>
-            <a class="quickgo-link selectable" ng-click="showEvidenceCodeOntologyGraph(goTuple.evidenceEco)">{{goTuple.evidenceEco}}</a>
-            &nbsp;<a class="quickgo-link" href="http://geneontology.org/page/guide-go-evidence-codes#iea"
+            <a class="quickgo-link selectable" href="#/term/{{goTuple.evidenceEco}}">{{goTuple.evidenceEco}}</a>
+            &nbsp;<a class="quickgo-link" href="http://geneontology.org/page/guide-go-evidence-codes#{{goTuple.evidenceGo | lowercase}}"
                      target="_blank">({{goTuple.evidenceGo}})</a>
+            <a class="quickgo-link selectable" ng-click="showEvidenceCodeOntologyGraph(goTuple.evidenceEco)">
+              <span class="icon icon-functional quickgo-btn chart-btn selectable" data-icon="h"></span>
+            </a>
           </td>
 
           <!-- Reference eg "GO_REF:0000002" -->


### PR DESCRIPTION
Changing the links to go to the correct locations, and also adding a map icon link for the ECO