### PR TITLE
GOA-1979 - changing the basket icon to not show an change during mous…

### DIFF
--- a/app/directives/basket.html
+++ b/app/directives/basket.html
@@ -1,8 +1,6 @@
 <span
-	class="icon selectable quickgo-btn basket-btn"
-	ng-class="{'basket-added': inBasket, 'icon-generic': !hoverBasket, 'icon-functional': hoverBasket, 'icon-disabled': (iconDisabledStatus === 'true')}"
+	class="icon selectable quickgo-btn basket-btn icon-generic"
+	ng-class="{'basket-added': inBasket, 'icon-disabled': (iconDisabledStatus === 'true')}"
 	data-icon="{{getDataIcon()}}"
-	ng-mouseenter="hoverBasket = true"
-	ng-mouseleave="hoverBasket = false"
 	ng-if="showIcon === true">
 </span>


### PR DESCRIPTION
…eover. i.e. stay as a basket always

This is a temporary fix until we can work out why the icon has stopped changing.

The ng-mouseover action does work (as it changes the font family in the ng-class), but the value of "hoverBakset" is never evaluated as "true" in the associated js file, and critically the function "$scope.getDataIcon"  (which is in charge of swapping gate icon over).