### PR TITLE
Goa 2568 annotation ext

### DIFF
--- a/app/advancedfilters/advancedFilters.html
+++ b/app/advancedfilters/advancedFilters.html
@@ -71,6 +71,17 @@
       </dropdown-toggle>
     </li>
 
+    <!-- ANNOTATION EXTENSION -->
+    <li ng-class="{'inactive':query.extension}">
+      <dropdown-toggle close-on-click="true" class="evidence-panel" pane-align="right">
+        <toggle>
+          <button class="button dropdown" ng-class="{'icon-functional active-filter' : query['extension']}" data-icon="/">Annotation Extension</button>
+        </toggle>
+        <pane>
+          <div ng-include src="'advancedfilters/annotationExtensionFilter.html'"></div>
+        </pane>
+      </dropdown-toggle>
+    </li>
 
     <!-- MORE  -->
 

--- a/app/advancedfilters/annotationExtensionFilter.html
+++ b/app/advancedfilters/annotationExtensionFilter.html
@@ -1,0 +1,26 @@
+<div ng-controller="annotationExtensionFilterController">
+  <div class="callout primary text-center">
+    <small>{{extension.length > 0 ? extension : 'Annotation extension query'}}</small>
+  </div>
+  <div class="row">
+    <div class="medium-4 columns">
+      <label>
+        Relationship
+        <input type="text" placeholder=" *, occurs_in, has_input, directly_regulates, ..." ng-model="relationship">
+      </label>
+    </div>
+    <div class="medium-6 columns">
+      <label>
+        Database ID
+        <input type="text" placeholder=" *, UniProtKB, UBERON:0000922, ..." ng-model="dbId">
+      </label>
+    </div>
+    <div class="medium-2 columns">
+      <button type="button" class="hollow button in-form-button" ng-click="addComponent()" ng-disabled="!relationship || !dbId">Add</button>
+    </div>
+  </div>
+  <hr>
+  <div class="pull-right">
+    <filter-buttons></filter-buttons>
+  </div>
+</div>

--- a/app/advancedfilters/annotationExtensionFilter.js
+++ b/app/advancedfilters/annotationExtensionFilter.js
@@ -1,0 +1,38 @@
+app.controller('annotationExtensionFilterController', function($scope, presetsService, filterService, validationService){
+
+  $scope.extension = '';
+
+  var init = function() {
+    $scope.extension = '';
+  };
+
+  $scope.apply = function() {
+    $scope.$parent.addToQuery('extension', $scope.extension);
+  };
+
+  $scope.reset = function () {
+    $scope.$parent.query.extension = '';
+    init();
+  };
+
+  $scope.addComponent = function() {
+    if(validationService.validateGeneProduct($scope.dbId)) {
+      var component = $scope.relationship + '(' + $scope.dbId + ')';
+      $scope.extension = $scope.extension + ($scope.extension ? ',' : '') + component;
+      $scope.relationship = '';
+      $scope.dbId = '';
+    } else {
+      // TODO message
+    }
+  };
+
+  $scope.$on('applyAEFilters', function() {
+    $scope.apply();
+  });
+
+  $scope.$on('resetAEFilters', function() {
+    $scope.reset();
+  });
+
+  init();
+});

--- a/app/advancedfilters/annotationExtensionFilter.js
+++ b/app/advancedfilters/annotationExtensionFilter.js
@@ -3,7 +3,7 @@ app.controller('annotationExtensionFilterController', function($scope, presetsSe
   $scope.extension = '';
 
   var init = function() {
-    $scope.extension = '';
+    $scope.extension = $scope.$parent.query.extension ? $scope.$parent.query.extension : '';
   };
 
   $scope.apply = function() {
@@ -13,17 +13,14 @@ app.controller('annotationExtensionFilterController', function($scope, presetsSe
   $scope.reset = function () {
     $scope.$parent.query.extension = '';
     init();
+    $scope.$parent.updateQuery();
   };
 
   $scope.addComponent = function() {
-    if(validationService.validateGeneProduct($scope.dbId)) {
       var component = $scope.relationship + '(' + $scope.dbId + ')';
       $scope.extension = $scope.extension + ($scope.extension ? ',' : '') + component;
       $scope.relationship = '';
       $scope.dbId = '';
-    } else {
-      // TODO message
-    }
   };
 
   $scope.$on('applyAEFilters', function() {

--- a/app/index.html
+++ b/app/index.html
@@ -277,6 +277,7 @@
 <script src="advancedfilters/referencesFilter.js"></script>
 <script src="advancedfilters/qualifierFilter.js"></script>
 <script src="advancedfilters/assignedByFilter.js"></script>
+<script src="advancedfilters/annotationExtensionFilter.js"></script>
 <script src="advancedfilters/filterButtons.js"></script>
 <script src="download/download.js"></script>
 <script src="download/downloadStatistics.js"></script>

--- a/app/styles/quickgo.scss
+++ b/app/styles/quickgo.scss
@@ -197,6 +197,11 @@ span.has-tip{
 }
 
 
+.in-form-button {
+  margin-top: 1.6em;
+}
+
+
 
 /*   RESULTS page  -------------------------------------------------------*/
 


### PR DESCRIPTION
- Relationship is currently free text, but will be an autocomplete as soon as the backend service is provided
- the BE doesn’t currently support `part_of (UBERON)` and supports `part_of (UBERON:0000010)` only
- I haven’t added validation to the db if field, but if we only support `UBERON:0000010` and not `UBERON` I can use the gene product validator