### PR TITLE
Goa 3103 stats tab

### DIFF
--- a/app/directives/statsTable.html
+++ b/app/directives/statsTable.html
@@ -12,7 +12,7 @@
             obsolete="mapping[item.key].obsolete" name="mapping[item.key].name"></term-line>
           <strong ng-if="!isTerm">{{item.key}}</strong>
         </td>
-        <td>{{item.percentage * 100 | number:2}}</td>
+        <td>{{item.percentage | number:2}}</td>
         <td>{{item.hits | number:0}}</td>
       </tr>
     </table>

--- a/app/statistics/statistics.html
+++ b/app/statistics/statistics.html
@@ -23,7 +23,6 @@
             <tab heading="{{stats.geneProductId.label}}" ng-show="stats.geneProductId.annotation.length > 0">
                 <div class="row expanded">
                     <stats-table title="Annotations per Gene Product ID" items="stats.geneProductId.annotation" is-term="true" mapping="goTermMapping"></stats-table>
-                    <!-- <stats-table title="Gene products per Assigned By" items="stats.assignedBy.geneProduct"></stats-table> -->
                 </div>
             </tab>
             <tab heading="{{stats.annotationsForGoId.label}}" ng-show="stats.annotationsForGoId.geneProduct.length > 0">

--- a/app/statistics/statistics.html
+++ b/app/statistics/statistics.html
@@ -20,6 +20,12 @@
                     </div>
                 </div>
             </tab>
+            <tab heading="{{stats.geneProductId.label}}" ng-show="stats.geneProductId.annotation.length > 0">
+                <div class="row expanded">
+                    <stats-table title="Annotations per Gene Product ID" items="stats.geneProductId.annotation" is-term="true" mapping="goTermMapping"></stats-table>
+                    <!-- <stats-table title="Gene products per Assigned By" items="stats.assignedBy.geneProduct"></stats-table> -->
+                </div>
+            </tab>
             <tab heading="{{stats.annotationsForGoId.label}}" ng-show="stats.annotationsForGoId.geneProduct.length > 0">
                 <div class="row expanded">
                     <stats-table title="Annotations per slim term" items="stats.annotationsForGoId.geneProduct" is-term="true" mapping="goTermMapping"></stats-table>

--- a/app/statistics/statistics.js
+++ b/app/statistics/statistics.js
@@ -8,7 +8,8 @@ app.controller('StatisticsCtrl', function($scope, $routeParams, searchService, t
         'taxonId': { label: 'Taxon', selected: true },
         'evidenceCode': { label: 'Evidence', selected: true },
         'aspect': { label: 'Aspect', selected: true },
-        'annotationsForGoId': {label: 'Slim summary', selected: true}
+        'annotationsForGoId': {label: 'Slim summary', selected: true},
+        'geneProductId': {label: 'Gene Product ID', selected: true}
     };
 
     $scope.totalNumberAnnotations = 0;


### PR DESCRIPTION
This is to add a tab that shows the breakdown of % and # of annotations per Gene Product ID when this data is relevant and available in the Statistics area